### PR TITLE
feat: 배너 이미지 크롭 기능 추가 및 높이 증가

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -20,7 +20,8 @@
       "Bash(gh pr create:*)",
       "Bash(open https://github.com/blissful-y0/shinya_calendar/pull/new/feature/build-configuration)",
       "Bash(find:*)",
-      "Bash(for:*)"
+      "Bash(for:*)",
+      "Bash(git pull:*)"
     ],
     "deny": [],
     "ask": []

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "electron-store": "^10.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
+    "react-easy-crop": "^5.5.2",
     "react-icons": "^5.5.0",
     "recoil": "^0.7.7",
     "uuid": "^9.0.1"

--- a/src/components/Common/BannerCropModal.module.scss
+++ b/src/components/Common/BannerCropModal.module.scss
@@ -1,0 +1,194 @@
+@use '@styles/variables' as *;
+@use '@styles/mixins' as *;
+
+.modalOverlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.7);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 100000;
+  animation: fadeIn $transition-fast;
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.modalContent {
+  background: var(--color-surface);
+  border-radius: $border-radius-large;
+  width: 90%;
+  max-width: 800px;
+  max-height: 90vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: $shadow-large;
+  animation: slideUp $transition-normal;
+}
+
+@keyframes slideUp {
+  from {
+    opacity: 0;
+    transform: translateY(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.header {
+  padding: $spacing-lg;
+  border-bottom: 1px solid var(--color-border);
+
+  h2 {
+    margin: 0 0 $spacing-xs 0;
+    font-size: $font-size-large;
+    font-weight: $font-weight-semibold;
+    color: var(--color-text);
+  }
+
+  p {
+    margin: 0;
+    font-size: $font-size-small;
+    color: var(--color-text-secondary);
+  }
+}
+
+.cropperContainer {
+  position: relative;
+  height: 400px;
+  background: #f8f8f8;
+  margin: $spacing-lg;
+  border-radius: $border-radius-medium;
+  overflow: hidden;
+}
+
+.controls {
+  padding: 0 $spacing-lg;
+  margin-bottom: $spacing-lg;
+}
+
+.zoomControl {
+  display: flex;
+  align-items: center;
+  gap: $spacing-md;
+
+  label {
+    font-size: $font-size-small;
+    font-weight: $font-weight-medium;
+    color: var(--color-text);
+    min-width: 80px;
+  }
+}
+
+.zoomSlider {
+  flex: 1;
+  height: 4px;
+  border-radius: 2px;
+  background: var(--color-border);
+  outline: none;
+  -webkit-appearance: none;
+  appearance: none;
+
+  &::-webkit-slider-thumb {
+    -webkit-appearance: none;
+    appearance: none;
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: var(--color-primary);
+    cursor: pointer;
+    transition: all $transition-fast;
+
+    &:hover {
+      transform: scale(1.2);
+      box-shadow: 0 0 0 4px rgba(var(--color-primary), 0.2);
+    }
+  }
+
+  &::-moz-range-thumb {
+    width: 20px;
+    height: 20px;
+    border-radius: 50%;
+    background: var(--color-primary);
+    cursor: pointer;
+    border: none;
+    transition: all $transition-fast;
+
+    &:hover {
+      transform: scale(1.2);
+      box-shadow: 0 0 0 4px rgba(var(--color-primary), 0.2);
+    }
+  }
+
+  &::-webkit-slider-runnable-track {
+    background: linear-gradient(
+      to right,
+      var(--color-primary) 0%,
+      var(--color-primary) var(--progress),
+      var(--color-border) var(--progress),
+      var(--color-border) 100%
+    );
+  }
+}
+
+.actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: $spacing-sm;
+  padding: $spacing-lg;
+  border-top: 1px solid var(--color-border);
+}
+
+.cancelButton,
+.confirmButton {
+  @include button-reset;
+  display: flex;
+  align-items: center;
+  gap: $spacing-xs;
+  padding: $spacing-sm $spacing-md;
+  border-radius: $border-radius-medium;
+  font-size: $font-size-medium;
+  font-weight: $font-weight-medium;
+  transition: all $transition-fast;
+  cursor: pointer;
+
+  svg {
+    font-size: 18px;
+  }
+
+  &:active {
+    transform: scale(0.98);
+  }
+}
+
+.cancelButton {
+  background: var(--color-accent);
+  color: var(--color-text);
+
+  &:hover {
+    background: var(--color-border);
+  }
+}
+
+.confirmButton {
+  background: var(--color-primary);
+  color: white;
+
+  &:hover {
+    background: var(--color-secondary);
+    transform: translateY(-1px);
+    box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+  }
+}

--- a/src/components/Common/BannerCropModal.tsx
+++ b/src/components/Common/BannerCropModal.tsx
@@ -1,0 +1,171 @@
+import React, { useState, useCallback, useEffect } from 'react';
+import ReactDOM from 'react-dom';
+import Cropper from 'react-easy-crop';
+import { Point, Area } from 'react-easy-crop';
+import { MdCheck, MdClose } from 'react-icons/md';
+import styles from './BannerCropModal.module.scss';
+
+interface BannerCropModalProps {
+  imageSrc: string;
+  onCropComplete: (croppedImage: string) => void;
+  onClose: () => void;
+}
+
+const createImage = (url: string): Promise<HTMLImageElement> =>
+  new Promise((resolve, reject) => {
+    const image = new Image();
+    image.addEventListener('load', () => resolve(image));
+    image.addEventListener('error', error => reject(error));
+    image.setAttribute('crossOrigin', 'anonymous');
+    image.src = url;
+  });
+
+const getCroppedImg = async (
+  imageSrc: string,
+  pixelCrop: Area
+): Promise<string> => {
+  const image = await createImage(imageSrc);
+  const canvas = document.createElement('canvas');
+  const ctx = canvas.getContext('2d');
+
+  if (!ctx) {
+    throw new Error('No 2d context');
+  }
+
+  canvas.width = pixelCrop.width;
+  canvas.height = pixelCrop.height;
+
+  ctx.drawImage(
+    image,
+    pixelCrop.x,
+    pixelCrop.y,
+    pixelCrop.width,
+    pixelCrop.height,
+    0,
+    0,
+    pixelCrop.width,
+    pixelCrop.height
+  );
+
+  return new Promise((resolve, reject) => {
+    canvas.toBlob(blob => {
+      if (!blob) {
+        reject(new Error('Canvas is empty'));
+        return;
+      }
+      const reader = new FileReader();
+      reader.readAsDataURL(blob);
+      reader.onloadend = () => {
+        resolve(reader.result as string);
+      };
+    }, 'image/jpeg');
+  });
+};
+
+const BannerCropModal: React.FC<BannerCropModalProps> = ({
+  imageSrc,
+  onCropComplete,
+  onClose
+}) => {
+  const [crop, setCrop] = useState<Point>({ x: 0, y: 0 });
+  const [zoom, setZoom] = useState(1);
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState<Area | null>(null);
+
+  // ESC 키로 닫기
+  useEffect(() => {
+    const handleEsc = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleEsc);
+    return () => window.removeEventListener('keydown', handleEsc);
+  }, [onClose]);
+
+  const onCropAreaChange = useCallback(
+    (croppedArea: Area, croppedAreaPixels: Area) => {
+      setCroppedAreaPixels(croppedAreaPixels);
+    },
+    []
+  );
+
+  const handleCropComplete = async () => {
+    if (croppedAreaPixels) {
+      try {
+        const croppedImage = await getCroppedImg(imageSrc, croppedAreaPixels);
+        onCropComplete(croppedImage);
+      } catch (e) {
+        console.error(e);
+      }
+    }
+  };
+
+  const modalContent = (
+    <div className={styles.modalOverlay} onClick={onClose}>
+      <div className={styles.modalContent} onClick={(e) => e.stopPropagation()}>
+        <div className={styles.header}>
+          <h2>배너 영역 선택</h2>
+          <p>배너에 표시될 영역을 선택하세요</p>
+        </div>
+
+        <div className={styles.cropperContainer}>
+          <Cropper
+            image={imageSrc}
+            crop={crop}
+            zoom={zoom}
+            aspect={6} // 1200:200 ratio
+            onCropChange={setCrop}
+            onCropComplete={onCropAreaChange}
+            onZoomChange={setZoom}
+            restrictPosition={true}
+            style={{
+              containerStyle: {
+                background: '#f0f0f0',
+              },
+            }}
+          />
+        </div>
+
+        <div className={styles.controls}>
+          <div className={styles.zoomControl}>
+            <label>확대/축소</label>
+            <input
+              type="range"
+              value={zoom}
+              min={1}
+              max={3}
+              step={0.1}
+              onChange={(e) => setZoom(Number(e.target.value))}
+              className={styles.zoomSlider}
+            />
+          </div>
+        </div>
+
+        <div className={styles.actions}>
+          <button
+            className={styles.cancelButton}
+            onClick={onClose}
+          >
+            <MdClose />
+            취소
+          </button>
+          <button
+            className={styles.confirmButton}
+            onClick={handleCropComplete}
+          >
+            <MdCheck />
+            적용
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+
+  // React Portal을 사용하여 body에 직접 렌더링
+  return ReactDOM.createPortal(
+    modalContent,
+    document.body
+  );
+};
+
+export default BannerCropModal;

--- a/src/components/Common/CustomBanner.module.scss
+++ b/src/components/Common/CustomBanner.module.scss
@@ -4,7 +4,7 @@
 .bannerContainer {
   position: relative;
   width: 100%;
-  height: 120px;
+  height: 200px;
   margin-bottom: $spacing-md;
   cursor: pointer;
   overflow: hidden;
@@ -21,12 +21,12 @@
 
   // 작은 화면 최적화
   @media (max-height: 700px) {
-    height: 80px;
+    height: 150px;
     margin-bottom: $spacing-xs;
   }
 
   @media (max-height: 600px) {
-    height: 60px;
+    height: 120px;
   }
 }
 
@@ -93,6 +93,7 @@
 }
 
 .changeButton,
+.cropButton,
 .removeButton {
   @include button-reset;
   width: 36px;
@@ -116,6 +117,13 @@
 
   &:active {
     transform: scale(0.95);
+  }
+}
+
+.cropButton {
+  &:hover {
+    background: var(--color-primary);
+    color: white;
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2722,6 +2722,11 @@ normalize-url@^6.0.1:
   resolved "https://registry.yarnpkg.com/normalize-url/-/normalize-url-6.1.0.tgz#40d0885b535deffe3f3147bec877d05fe4c5668a"
   integrity sha512-DlL+XwOy3NxAQ8xuC0okPgK46iuVNAK01YN7RueYBqqFeGsBjV9XmCAzAdgt+667bCl5kPh9EqKKDwnaPG1I7A==
 
+normalize-wheel@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/normalize-wheel/-/normalize-wheel-1.0.1.tgz#aec886affdb045070d856447df62ecf86146ec45"
+  integrity sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==
+
 object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
@@ -2891,6 +2896,14 @@ react-dom@^18.2.0:
   dependencies:
     loose-envify "^1.1.0"
     scheduler "^0.23.2"
+
+react-easy-crop@^5.5.2:
+  version "5.5.2"
+  resolved "https://registry.yarnpkg.com/react-easy-crop/-/react-easy-crop-5.5.2.tgz#cb73422732ce4368776c5d6b3c564adef8a392f5"
+  integrity sha512-8sxx7x7QBMF8fi+zd9QTf9MXovPzQUASNCRrXy/ZUQe9r25U0yDweyM38CaoNTAfX9+k/v52ywLRXiwDN3TBtQ==
+  dependencies:
+    normalize-wheel "^1.0.1"
+    tslib "^2.0.1"
 
 react-icons@^5.5.0:
   version "5.5.0"
@@ -3451,7 +3464,7 @@ ts-api-utils@^1.3.0:
   resolved "https://registry.yarnpkg.com/ts-api-utils/-/ts-api-utils-1.4.3.tgz#bfc2215fe6528fecab2b0fba570a2e8a4263b064"
   integrity sha512-i3eMG77UTMD0hZhgRS562pv83RC6ukSAC2GMNWc+9dieh/+jDM5u5YG+NHX6VNDRHQcHwmsTHctP9LhbC3WxVw==
 
-tslib@^2.1.0:
+tslib@^2.0.1, tslib@^2.1.0:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==


### PR DESCRIPTION
- 배너 높이를 120px에서 200px로 증가 (반응형 지원)
- react-easy-crop 라이브러리를 사용한 이미지 크롭 기능 구현
- 이미지 업로드 시 자동으로 크롭 모달 표시
- 기존 배너 이미지 크롭 버튼 추가
- React Portal을 사용하여 모달 렌더링 개선
- 크롭 모달 열릴 때 스티커 편집 모드 자동 비활성화
- ESC 키로 모달 닫기 기능 추가

🤖 Generated with [Claude Code](https://claude.ai/code)