### PR TITLE
feat: 스티커 편집 모드 시작 시 자동으로 스티커 표시 활성화

### DIFF
--- a/src/components/Styling/StylingManager.tsx
+++ b/src/components/Styling/StylingManager.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { useRecoilState, useSetRecoilState, useRecoilValue } from 'recoil';
-import { stickerEditModeState, modalActiveState, stickersState, stickerLayoutsState, uploadedStickersState } from '@store/atoms';
+import { stickerEditModeState, modalActiveState, stickersState, stickerLayoutsState, uploadedStickersState, stickerVisibilityState } from '@store/atoms';
 import { MdBrush, MdClose, MdImage, MdEdit, MdEditOff, MdDelete, MdPhotoLibrary, MdRestore, MdFolder, MdMoreVert } from 'react-icons/md';
 import { format } from 'date-fns';
 import { ko } from 'date-fns/locale';
@@ -23,6 +23,7 @@ const StylingManager: React.FC<StylingManagerProps> = ({ onClose }) => {
   const [stickerLayouts, setStickerLayouts] = useRecoilState(stickerLayoutsState);
   const [uploadedStickers, setUploadedStickers] = useRecoilState(uploadedStickersState);
   const [layoutMenuId, setLayoutMenuId] = useState<string | null>(null);
+  const setStickerVisibility = useSetRecoilState(stickerVisibilityState);
 
   const handleBackdropClick = (e: React.MouseEvent) => {
     if (e.target === e.currentTarget) {
@@ -38,8 +39,9 @@ const StylingManager: React.FC<StylingManagerProps> = ({ onClose }) => {
 
   const toggleStickerEditMode = () => {
     setStickerEditMode(!stickerEditMode);
-    // 편집 시작 시 스타일링 매니저 창 닫기
+    // 편집 시작 시 스타일링 매니저 창 닫기 및 스티커 표시 강제 활성화
     if (!stickerEditMode) {
+      setStickerVisibility(true); // 편집 모드 시작 시 스티커 표시 강제로 켜기
       onClose();
     }
   };


### PR DESCRIPTION
- 편집 모드 진입 시 헤더의 스티커 표시 버튼이 자동으로 ON 상태로 변경
- 사용자가 편집 모드에서 스티커를 놓치는 문제 방지

🤖 Generated with [Claude Code](https://claude.ai/code)