### PR TITLE
feat: Windows용 커스텀 타이틀바 구현

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -36,10 +36,10 @@ function createWindow() {
       webgl: true,
       experimentalFeatures: true
     },
-    // 커스텀 타이틀바를 위해 기본 타이틀바 숨김
-    titleBarStyle: 'hidden',
+    // Windows에서는 frameless, macOS에서는 hidden 사용
+    ...(isWindows ? { frame: false } : { titleBarStyle: 'hidden' }),
     // macOS에서 트래픽 라이트 버튼 위치 조정
-    trafficLightPosition: { x: 15, y: 13 },
+    ...(isMac ? { trafficLightPosition: { x: 15, y: 13 } } : {}),
     backgroundColor: '#faf8f5',
     show: false
   });
@@ -127,6 +127,40 @@ ipcMain.handle('store-has', (_, key: string) => {
 
 ipcMain.handle('get-app-path', () => {
   return app.getPath('userData');
+});
+
+// Window control handlers
+ipcMain.handle('minimize-window', () => {
+  if (mainWindow) {
+    mainWindow.minimize();
+  }
+});
+
+ipcMain.handle('maximize-window', () => {
+  if (mainWindow) {
+    if (mainWindow.isMaximized()) {
+      mainWindow.restore();
+    } else {
+      mainWindow.maximize();
+    }
+  }
+});
+
+ipcMain.handle('close-window', () => {
+  if (mainWindow) {
+    mainWindow.close();
+  }
+});
+
+ipcMain.handle('is-maximized', () => {
+  if (mainWindow) {
+    return mainWindow.isMaximized();
+  }
+  return false;
+});
+
+ipcMain.handle('get-platform', () => {
+  return process.platform;
 });
 
 // Window resize API handler

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -4,6 +4,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getAppPath: () => ipcRenderer.invoke('get-app-path'),
   resizeWindow: (width: number, height: number) => ipcRenderer.invoke('resize-window', width, height),
 
+  // 윈도우 컨트롤
+  minimizeWindow: () => ipcRenderer.invoke('minimize-window'),
+  maximizeWindow: () => ipcRenderer.invoke('maximize-window'),
+  closeWindow: () => ipcRenderer.invoke('close-window'),
+  isMaximized: () => ipcRenderer.invoke('is-maximized'),
+  getPlatform: () => ipcRenderer.invoke('get-platform'),
+
   // 앱 종료 전 이벤트 리스너
   onAppBeforeQuit: (callback: () => void) => ipcRenderer.on('app-before-quit', callback),
   removeAppBeforeQuitListener: (callback: () => void) => ipcRenderer.removeListener('app-before-quit', callback),

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useCallback } from "react";
 import { useRecoilValue, useSetRecoilState, useRecoilState } from "recoil";
 import { sidebarOpenState, viewModeState, stickerEditModeState, stickersState, currentThemeState, bannerImageState } from "@store/atoms";
 import TitleBar from "@components/Layout/TitleBar";
+import WindowTitleBar from "@components/Common/WindowTitleBar";
 import Header from "@components/Common/Header";
 import Calendar from "@components/Calendar/Calendar";
 import DayView from "@components/Calendar/DayView";
@@ -136,6 +137,7 @@ function App() {
 
   return (
     <div className={styles.app}>
+      <WindowTitleBar />
       <TitleBar />
       <Header />
       <div className={styles.mainContent}>

--- a/src/components/Common/WindowTitleBar.module.scss
+++ b/src/components/Common/WindowTitleBar.module.scss
@@ -1,0 +1,77 @@
+@use '@styles/variables' as *;
+@use '@styles/mixins' as *;
+
+.titleBar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 32px;
+  background: var(--color-background);
+  border-bottom: 1px solid var(--color-border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  z-index: 10000;
+  user-select: none;
+  -webkit-app-region: drag;
+}
+
+.dragRegion {
+  flex: 1;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  padding-left: $spacing-md;
+}
+
+.title {
+  font-size: $font-size-small;
+  font-weight: $font-weight-medium;
+  color: var(--color-text);
+  pointer-events: none;
+}
+
+.windowControls {
+  display: flex;
+  height: 100%;
+  -webkit-app-region: no-drag;
+}
+
+.windowButton {
+  @include button-reset;
+  width: 46px;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: transparent;
+  border: none;
+  color: var(--color-text-secondary);
+  transition: all $transition-fast;
+
+  &:hover {
+    background: var(--color-hover);
+  }
+
+  &:active {
+    background: var(--color-active);
+  }
+
+  svg {
+    width: 16px;
+    height: 16px;
+  }
+}
+
+.closeButton {
+  &:hover {
+    background: #e81123;
+    color: white;
+  }
+
+  &:active {
+    background: #f1707a;
+    color: white;
+  }
+}

--- a/src/components/Common/WindowTitleBar.tsx
+++ b/src/components/Common/WindowTitleBar.tsx
@@ -1,0 +1,91 @@
+import React, { useEffect, useState } from 'react';
+import { VscChromeMinimize, VscChromeMaximize, VscChromeRestore, VscChromeClose } from 'react-icons/vsc';
+import styles from './WindowTitleBar.module.scss';
+
+const WindowTitleBar: React.FC = () => {
+  const [isMaximized, setIsMaximized] = useState(false);
+  const [platform, setPlatform] = useState<string>('');
+
+  useEffect(() => {
+    // 플랫폼 체크
+    if (window.electronAPI?.getPlatform) {
+      window.electronAPI.getPlatform().then(setPlatform);
+    }
+
+    // 최대화 상태 체크
+    const checkMaximized = async () => {
+      if (window.electronAPI?.isMaximized) {
+        const maximized = await window.electronAPI.isMaximized();
+        setIsMaximized(maximized);
+      }
+    };
+
+    checkMaximized();
+
+    // 윈도우 리사이즈 이벤트 리스너
+    const handleResize = () => checkMaximized();
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  const handleMinimize = () => {
+    if (window.electronAPI?.minimizeWindow) {
+      window.electronAPI.minimizeWindow();
+    }
+  };
+
+  const handleMaximize = async () => {
+    if (window.electronAPI?.maximizeWindow) {
+      await window.electronAPI.maximizeWindow();
+      const maximized = await window.electronAPI.isMaximized();
+      setIsMaximized(maximized);
+    }
+  };
+
+  const handleClose = () => {
+    if (window.electronAPI?.closeWindow) {
+      window.electronAPI.closeWindow();
+    }
+  };
+
+  // Windows 플랫폼이 아니면 타이틀바를 표시하지 않음
+  if (platform !== 'win32') {
+    return null;
+  }
+
+  return (
+    <div className={styles.titleBar}>
+      <div className={styles.dragRegion}>
+        <span className={styles.title}>신야 캘린더</span>
+      </div>
+      <div className={styles.windowControls}>
+        <button
+          className={styles.windowButton}
+          onClick={handleMinimize}
+          title="최소화"
+        >
+          <VscChromeMinimize />
+        </button>
+        <button
+          className={styles.windowButton}
+          onClick={handleMaximize}
+          title={isMaximized ? "복원" : "최대화"}
+        >
+          {isMaximized ? <VscChromeRestore /> : <VscChromeMaximize />}
+        </button>
+        <button
+          className={`${styles.windowButton} ${styles.closeButton}`}
+          onClick={handleClose}
+          title="닫기"
+        >
+          <VscChromeClose />
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default WindowTitleBar;

--- a/src/components/Styling/StickerCanvas.tsx
+++ b/src/components/Styling/StickerCanvas.tsx
@@ -1,9 +1,15 @@
-import React, { useRef, useState, useEffect, useCallback } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
-import { stickersState, stickerEditModeState, modalActiveState, stickerLayoutsState, stickerVisibilityState } from '@store/atoms';
-import { MdDelete } from 'react-icons/md';
-import { Sticker } from './StickerPanel';
-import styles from './StickerCanvas.module.scss';
+import React, { useRef, useState, useEffect, useCallback } from "react";
+import { useRecoilState, useRecoilValue } from "recoil";
+import {
+  stickersState,
+  stickerEditModeState,
+  modalActiveState,
+  stickerLayoutsState,
+  stickerVisibilityState,
+} from "@store/atoms";
+import { MdDelete } from "react-icons/md";
+import { Sticker } from "./StickerPanel";
+import styles from "./StickerCanvas.module.scss";
 
 interface DraggingState {
   id: string;
@@ -52,12 +58,8 @@ const StickerCanvas: React.FC = () => {
     setSelectedSticker(sticker.id);
 
     // 선택된 스티커를 맨 앞으로 가져오기
-    setStickers(prev =>
-      prev.map(s =>
-        s.id === sticker.id
-          ? { ...s, zIndex: Date.now() }
-          : s
-      )
+    setStickers((prev) =>
+      prev.map((s) => (s.id === sticker.id ? { ...s, zIndex: Date.now() } : s))
     );
   };
 
@@ -70,7 +72,7 @@ const StickerCanvas: React.FC = () => {
       startWidth: sticker.width,
       startHeight: sticker.height,
       startX: e.clientX,
-      startY: e.clientY
+      startY: e.clientY,
     });
     setSelectedSticker(sticker.id);
   };
@@ -87,73 +89,83 @@ const StickerCanvas: React.FC = () => {
     const mouseX = e.clientX - rect.left;
     const mouseY = e.clientY - rect.top;
 
-    const startAngle = Math.atan2(mouseY - centerY, mouseX - centerX) * 180 / Math.PI - sticker.rotation;
+    const startAngle =
+      (Math.atan2(mouseY - centerY, mouseX - centerX) * 180) / Math.PI -
+      sticker.rotation;
 
     setRotating({
       id: sticker.id,
       startAngle,
       centerX,
-      centerY
+      centerY,
     });
     setSelectedSticker(sticker.id);
   };
 
   // 전역 마우스 이동 핸들러 (부드러운 드래그를 위해)
-  const handleGlobalMouseMove = useCallback((e: MouseEvent) => {
-    if (!dragging && !resizing && !rotating) return;
+  const handleGlobalMouseMove = useCallback(
+    (e: MouseEvent) => {
+      if (!dragging && !resizing && !rotating) return;
 
-    const rect = canvasRef.current?.getBoundingClientRect();
-    if (!rect) return;
+      const rect = canvasRef.current?.getBoundingClientRect();
+      if (!rect) return;
 
-    if (dragging) {
-      // 부드러운 이동을 위해 제한을 완화하고 더 자유로운 움직임 허용
-      const newX = e.clientX - rect.left - dragging.offsetX;
-      const newY = e.clientY - rect.top - dragging.offsetY;
+      if (dragging) {
+        // 부드러운 이동을 위해 제한을 완화하고 더 자유로운 움직임 허용
+        const newX = e.clientX - rect.left - dragging.offsetX;
+        const newY = e.clientY - rect.top - dragging.offsetY;
 
-      // 캔버스 경계를 벗어나지 않도록 하되, 여유를 둠
-      const boundedX = Math.max(-50, Math.min(newX, rect.width - 50));
-      const boundedY = Math.max(-50, Math.min(newY, rect.height - 50));
+        // 캔버스 경계를 벗어나지 않도록 하되, 여유를 둠
+        const boundedX = Math.max(-50, Math.min(newX, rect.width - 50));
+        const boundedY = Math.max(-50, Math.min(newY, rect.height - 50));
 
-      setStickers(prev =>
-        prev.map(s =>
-          s.id === dragging.id
-            ? { ...s, x: boundedX, y: boundedY }
-            : s
-        )
-      );
-    }
+        setStickers((prev) =>
+          prev.map((s) =>
+            s.id === dragging.id ? { ...s, x: boundedX, y: boundedY } : s
+          )
+        );
+      }
 
-    if (resizing) {
-      const deltaX = e.clientX - resizing.startX;
-      const deltaY = e.clientY - resizing.startY;
-      const delta = Math.max(deltaX, deltaY); // 비율 유지를 위해 더 큰 값 사용
-      const newWidth = Math.max(30, Math.min(resizing.startWidth + delta, 300));
-      const newHeight = Math.max(30, Math.min(resizing.startHeight + delta, 300));
+      if (resizing) {
+        const deltaX = e.clientX - resizing.startX;
+        const deltaY = e.clientY - resizing.startY;
+        const delta = Math.max(deltaX, deltaY); // 비율 유지를 위해 더 큰 값 사용
+        const newWidth = Math.max(
+          30,
+          Math.min(resizing.startWidth + delta, 300)
+        );
+        const newHeight = Math.max(
+          30,
+          Math.min(resizing.startHeight + delta, 300)
+        );
 
-      setStickers(prev =>
-        prev.map(s =>
-          s.id === resizing.id
-            ? { ...s, width: newWidth, height: newHeight }
-            : s
-        )
-      );
-    }
+        setStickers((prev) =>
+          prev.map((s) =>
+            s.id === resizing.id
+              ? { ...s, width: newWidth, height: newHeight }
+              : s
+          )
+        );
+      }
 
-    if (rotating) {
-      const mouseX = e.clientX - rect.left;
-      const mouseY = e.clientY - rect.top;
-      const currentAngle = Math.atan2(mouseY - rotating.centerY, mouseX - rotating.centerX) * 180 / Math.PI;
-      const newRotation = currentAngle - rotating.startAngle;
+      if (rotating) {
+        const mouseX = e.clientX - rect.left;
+        const mouseY = e.clientY - rect.top;
+        const currentAngle =
+          (Math.atan2(mouseY - rotating.centerY, mouseX - rotating.centerX) *
+            180) /
+          Math.PI;
+        const newRotation = currentAngle - rotating.startAngle;
 
-      setStickers(prev =>
-        prev.map(s =>
-          s.id === rotating.id
-            ? { ...s, rotation: newRotation }
-            : s
-        )
-      );
-    }
-  }, [dragging, resizing, rotating, setStickers]);
+        setStickers((prev) =>
+          prev.map((s) =>
+            s.id === rotating.id ? { ...s, rotation: newRotation } : s
+          )
+        );
+      }
+    },
+    [dragging, resizing, rotating, setStickers]
+  );
 
   const handleGlobalMouseUp = useCallback(() => {
     setDragging(null);
@@ -164,15 +176,21 @@ const StickerCanvas: React.FC = () => {
   // 전역 이벤트 리스너 등록
   useEffect(() => {
     if (dragging || resizing || rotating) {
-      document.addEventListener('mousemove', handleGlobalMouseMove);
-      document.addEventListener('mouseup', handleGlobalMouseUp);
+      document.addEventListener("mousemove", handleGlobalMouseMove);
+      document.addEventListener("mouseup", handleGlobalMouseUp);
 
       return () => {
-        document.removeEventListener('mousemove', handleGlobalMouseMove);
-        document.removeEventListener('mouseup', handleGlobalMouseUp);
+        document.removeEventListener("mousemove", handleGlobalMouseMove);
+        document.removeEventListener("mouseup", handleGlobalMouseUp);
       };
     }
-  }, [dragging, resizing, rotating, handleGlobalMouseMove, handleGlobalMouseUp]);
+  }, [
+    dragging,
+    resizing,
+    rotating,
+    handleGlobalMouseMove,
+    handleGlobalMouseUp,
+  ]);
 
   // 캔버스 클릭으로 선택 해제
   const handleCanvasClick = (e: React.MouseEvent) => {
@@ -196,13 +214,14 @@ const StickerCanvas: React.FC = () => {
     const handleResize = () => {
       const currentResolution = {
         width: window.innerWidth,
-        height: window.innerHeight
+        height: window.innerHeight,
       };
 
       // 현재 해상도에 맞는 레이아웃 찾기
       const matchingLayout = stickerLayouts.find(
-        layout => layout.resolution.width === currentResolution.width &&
-                 layout.resolution.height === currentResolution.height
+        (layout) =>
+          layout.resolution.width === currentResolution.width &&
+          layout.resolution.height === currentResolution.height
       );
 
       if (matchingLayout) {
@@ -214,17 +233,16 @@ const StickerCanvas: React.FC = () => {
     handleResize();
 
     // 윈도우 리사이즈 이벤트 리스너
-    window.addEventListener('resize', handleResize);
-    return () => window.removeEventListener('resize', handleResize);
+    window.addEventListener("resize", handleResize);
+    return () => window.removeEventListener("resize", handleResize);
   }, [stickerLayouts, setStickers]);
-
 
   const handleStickerRightClick = (e: React.MouseEvent, stickerId: string) => {
     if (!stickerEditMode) return;
 
     e.preventDefault();
-    if (confirm('이 스티커를 삭제하시겠습니까?')) {
-      setStickers(prev => prev.filter(s => s.id !== stickerId));
+    if (confirm("이 스티커를 삭제하시겠습니까?")) {
+      setStickers((prev) => prev.filter((s) => s.id !== stickerId));
       setSelectedSticker(null);
     }
   };
@@ -233,8 +251,8 @@ const StickerCanvas: React.FC = () => {
     e.preventDefault();
     e.stopPropagation();
 
-    if (confirm('이 스티커를 삭제하시겠습니까?')) {
-      setStickers(prev => prev.filter(s => s.id !== stickerId));
+    if (confirm("이 스티커를 삭제하시겠습니까?")) {
+      setStickers((prev) => prev.filter((s) => s.id !== stickerId));
       setSelectedSticker(null);
     }
   };
@@ -250,7 +268,7 @@ const StickerCanvas: React.FC = () => {
       className={styles.stickerCanvas}
       onClick={handleCanvasClick}
     >
-      {stickers.map(sticker => {
+      {stickers.map((sticker) => {
         const isSelected = selectedSticker === sticker.id;
         const isDragging = dragging?.id === sticker.id;
         const isResizing = resizing?.id === sticker.id;
@@ -259,7 +277,11 @@ const StickerCanvas: React.FC = () => {
         return (
           <div
             key={sticker.id}
-            className={`${styles.sticker} ${isDragging ? styles.dragging : ''} ${isSelected && stickerEditMode ? styles.selected : ''} ${!stickerEditMode ? styles.readOnly : ''}`}
+            className={`${styles.sticker} ${
+              isDragging ? styles.dragging : ""
+            } ${isSelected && stickerEditMode ? styles.selected : ""} ${
+              !stickerEditMode ? styles.readOnly : ""
+            }`}
             style={{
               left: sticker.x,
               top: sticker.y,
@@ -267,11 +289,15 @@ const StickerCanvas: React.FC = () => {
               height: sticker.height,
               zIndex: sticker.zIndex,
               backgroundImage: `url(${sticker.image})`,
-              transform: `rotate(${sticker.rotation}deg)`
+              transform: `rotate(${sticker.rotation}deg)`,
             }}
             onMouseDown={(e) => handleMouseDown(e, sticker)}
             onContextMenu={(e) => handleStickerRightClick(e, sticker.id)}
-            title={stickerEditMode ? "편집 모드: 클릭-선택 | 드래그-이동 | 핸들-크기/회전 조정 | X버튼-삭제 | 우클릭-삭제" : "읽기 전용 모드: 편집하려면 편집 모드를 활성화하세요"}
+            title={
+              stickerEditMode
+                ? "편집 모드: 클릭-선택 | 드래그-이동 | 핸들-크기/회전 조정 | X버튼-삭제 | 우클릭-삭제"
+                : "읽기 전용 모드: 편집하려면 편집 모드를 활성화하세요"
+            }
           >
             {isSelected && stickerEditMode && (
               <>

--- a/src/utils/electronStore.ts
+++ b/src/utils/electronStore.ts
@@ -2,7 +2,7 @@
 
 // Electron 환경인지 체크
 const isElectron = () => {
-  return typeof window !== 'undefined' && window.electronAPI !== undefined;
+  return typeof window !== "undefined" && window.electronAPI !== undefined;
 };
 
 // Store 유틸리티 함수들
@@ -12,9 +12,11 @@ export const electronStore = {
       try {
         return await window.electronAPI.store.get(key);
       } catch (error) {
-        console.error('Error getting from electron store:', error);
+        console.error("Error getting from electron store:", error);
         // 폴백으로 localStorage 사용
-        return localStorage.getItem(key) ? JSON.parse(localStorage.getItem(key)!) : null;
+        return localStorage.getItem(key)
+          ? JSON.parse(localStorage.getItem(key)!)
+          : null;
       }
     }
     // Electron이 아닌 환경에서는 localStorage 사용
@@ -29,7 +31,7 @@ export const electronStore = {
         // localStorage에도 백업으로 저장
         localStorage.setItem(key, JSON.stringify(value));
       } catch (error) {
-        console.error('Error setting to electron store:', error);
+        console.error("Error setting to electron store:", error);
         localStorage.setItem(key, JSON.stringify(value));
       }
     } else {
@@ -43,7 +45,7 @@ export const electronStore = {
         await window.electronAPI.store.delete(key);
         localStorage.removeItem(key);
       } catch (error) {
-        console.error('Error deleting from electron store:', error);
+        console.error("Error deleting from electron store:", error);
         localStorage.removeItem(key);
       }
     } else {
@@ -56,7 +58,7 @@ export const electronStore = {
       try {
         return await window.electronAPI.store.has(key);
       } catch (error) {
-        console.error('Error checking electron store:', error);
+        console.error("Error checking electron store:", error);
         return localStorage.getItem(key) !== null;
       }
     }
@@ -69,11 +71,11 @@ export const electronStore = {
         await window.electronAPI.store.clear();
         localStorage.clear();
       } catch (error) {
-        console.error('Error clearing electron store:', error);
+        console.error("Error clearing electron store:", error);
         localStorage.clear();
       }
     } else {
       localStorage.clear();
     }
-  }
+  },
 };

--- a/src/vite-env.d.ts
+++ b/src/vite-env.d.ts
@@ -3,6 +3,11 @@
 interface ElectronAPI {
   getAppPath: () => Promise<string>;
   resizeWindow: (width: number, height: number) => Promise<{ width: number; height: number }>;
+  minimizeWindow: () => Promise<void>;
+  maximizeWindow: () => Promise<void>;
+  closeWindow: () => Promise<void>;
+  isMaximized: () => Promise<boolean>;
+  getPlatform: () => Promise<string>;
   onAppBeforeQuit: (callback: () => void) => void;
   removeAppBeforeQuitListener: (callback: () => void) => void;
   store: {


### PR DESCRIPTION
- Windows 환경에서 frameless 윈도우용 커스텀 타이틀바 추가
- 최소화, 최대화/복원, 닫기 버튼 구현
- 플랫폼 감지를 통해 Windows에서만 표시
- Electron IPC 핸들러 추가 (minimize, maximize, close)
- react-icons 패키지 추가

🤖 Generated with [Claude Code](https://claude.ai/code)