### PR TITLE
feat: 뷰 모드별 캘린더 네비게이션 기능 개선

### DIFF
--- a/src/components/Calendar/Calendar.tsx
+++ b/src/components/Calendar/Calendar.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import {
   currentMonthState,
   selectedDateState,
+  selectedEventState,
   eventsState,
   diaryEntriesState,
   viewModeState
@@ -24,6 +25,7 @@ import styles from './Calendar.module.scss';
 const Calendar: React.FC = () => {
   const [currentMonth, setCurrentMonth] = useRecoilState(currentMonthState);
   const [selectedDate, setSelectedDate] = useRecoilState(selectedDateState);
+  const setSelectedEvent = useSetRecoilState(selectedEventState);
   const events = useRecoilValue(eventsState);
   const diaryEntries = useRecoilValue(diaryEntriesState);
   const viewMode = useRecoilValue(viewModeState);
@@ -74,7 +76,12 @@ const Calendar: React.FC = () => {
                 <div
                   key={event.id}
                   className={styles.eventItem}
-                  style={{ borderLeftColor: event.color }}
+                  style={{ borderLeftColor: event.color, cursor: 'pointer' }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setSelectedEvent(event);
+                    setSelectedDate(date);
+                  }}
                 >
                   <span className={styles.eventTime}>
                     {event.startTime}

--- a/src/components/Calendar/DayView.tsx
+++ b/src/components/Calendar/DayView.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
-import { selectedDateState, eventsState, diaryEntriesState } from '@store/atoms';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { selectedDateState, selectedEventState, eventsState, diaryEntriesState } from '@store/atoms';
 import { formatDate, isSameDayAs } from '@utils/calendar';
 import { getEventsForDate } from '@utils/eventUtils';
 import { Event } from '@types';
@@ -10,6 +10,7 @@ import styles from './DayView.module.scss';
 
 const DayView: React.FC = () => {
   const [selectedDate] = useRecoilState(selectedDateState);
+  const setSelectedEvent = useSetRecoilState(selectedEventState);
   const events = useRecoilValue(eventsState);
   const diaryEntries = useRecoilValue(diaryEntriesState);
 
@@ -71,7 +72,8 @@ const DayView: React.FC = () => {
               <div
                 key={event.id}
                 className={styles.allDayEvent}
-                style={{ backgroundColor: event.color }}
+                style={{ backgroundColor: event.color, cursor: 'pointer' }}
+                onClick={() => setSelectedEvent(event)}
               >
                 {event.title}
               </div>
@@ -101,8 +103,10 @@ const DayView: React.FC = () => {
                   style={{
                     top: `${position.top}px`,
                     height: `${position.height}px`,
-                    backgroundColor: event.color
+                    backgroundColor: event.color,
+                    cursor: 'pointer'
                   }}
+                  onClick={() => setSelectedEvent(event)}
                 >
                   <div className={styles.eventTime}>
                     {event.startTime}

--- a/src/components/Calendar/WeekView.tsx
+++ b/src/components/Calendar/WeekView.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
-import { selectedDateState, eventsState, diaryEntriesState } from '@store/atoms';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
+import { selectedDateState, selectedEventState, eventsState, diaryEntriesState } from '@store/atoms';
 import { getDaysInWeek, formatDate, isSameDayAs, isCurrentDay } from '@utils/calendar';
 import { getEventsForDate } from '@utils/eventUtils';
 import { startOfMonth, endOfMonth, addMonths } from 'date-fns';
@@ -9,6 +9,7 @@ import styles from './WeekView.module.scss';
 
 const WeekView: React.FC = () => {
   const [selectedDate, setSelectedDate] = useRecoilState(selectedDateState);
+  const setSelectedEvent = useSetRecoilState(selectedEventState);
   const events = useRecoilValue(eventsState);
   const diaryEntries = useRecoilValue(diaryEntriesState);
 
@@ -99,7 +100,11 @@ const WeekView: React.FC = () => {
                   <div
                     key={event.id}
                     className={styles.allDayEvent}
-                    style={{ backgroundColor: event.color }}
+                    style={{ backgroundColor: event.color, cursor: 'pointer' }}
+                    onClick={() => {
+                      setSelectedEvent(event);
+                      setSelectedDate(date);
+                    }}
                   >
                     {event.title}
                   </div>
@@ -145,7 +150,12 @@ const WeekView: React.FC = () => {
                         height: `${position.height}px`,
                         left: `${position.left}%`,
                         width: `calc(${position.width}% - 4px)`,
-                        backgroundColor: event.color
+                        backgroundColor: event.color,
+                        cursor: 'pointer'
+                      }}
+                      onClick={() => {
+                        setSelectedEvent(event);
+                        setSelectedDate(date);
                       }}
                     >
                       <div className={styles.eventTime}>

--- a/src/components/Common/Header.tsx
+++ b/src/components/Common/Header.tsx
@@ -1,8 +1,9 @@
 import React from "react";
-import { useRecoilState } from "recoil";
+import { useRecoilState, useSetRecoilState } from "recoil";
 import {
   currentMonthState,
   selectedDateState,
+  selectedEventState,
   sidebarOpenState,
   viewModeState,
   stickerVisibilityState,
@@ -17,6 +18,7 @@ const Header: React.FC = () => {
   const [selectedDate, setSelectedDate] = useRecoilState(selectedDateState);
   const [sidebarOpen, setSidebarOpen] = useRecoilState(sidebarOpenState);
   const [viewMode, setViewMode] = useRecoilState(viewModeState);
+  const setSelectedEvent = useSetRecoilState(selectedEventState);
   const [stickerVisibility, setStickerVisibility] = useRecoilState(
     stickerVisibilityState
   );
@@ -61,7 +63,9 @@ const Header: React.FC = () => {
     } else if (viewMode === "week") {
       return format(selectedDate, "yyyy년 M월", { locale: ko });
     } else {
-      return `${currentMonth.getFullYear()}년 ${monthNames[currentMonth.getMonth()]}`;
+      return `${currentMonth.getFullYear()}년 ${
+        monthNames[currentMonth.getMonth()]
+      }`;
     }
   };
 
@@ -100,14 +104,17 @@ const Header: React.FC = () => {
           onClick={() => setStickerVisibility(!stickerVisibility)}
           title={stickerVisibility ? "스티커 숨기기" : "스티커 보이기"}
         >
-          ☆
+          {stickerVisibility ? "ON" : "OFF"}
         </button>
         <div className={styles.viewToggle}>
           <button
             className={`${styles.viewButton} ${
               viewMode === "day" ? styles.active : ""
             }`}
-            onClick={() => setViewMode("day")}
+            onClick={() => {
+              setViewMode("day");
+              setSelectedEvent(null);
+            }}
           >
             일
           </button>
@@ -115,7 +122,10 @@ const Header: React.FC = () => {
             className={`${styles.viewButton} ${
               viewMode === "week" ? styles.active : ""
             }`}
-            onClick={() => setViewMode("week")}
+            onClick={() => {
+              setViewMode("week");
+              setSelectedEvent(null);
+            }}
           >
             주
           </button>
@@ -123,7 +133,10 @@ const Header: React.FC = () => {
             className={`${styles.viewButton} ${
               viewMode === "month" ? styles.active : ""
             }`}
-            onClick={() => setViewMode("month")}
+            onClick={() => {
+              setViewMode("month");
+              setSelectedEvent(null);
+            }}
           >
             월
           </button>

--- a/src/components/Common/Header.tsx
+++ b/src/components/Common/Header.tsx
@@ -2,31 +2,67 @@ import React from "react";
 import { useRecoilState } from "recoil";
 import {
   currentMonthState,
+  selectedDateState,
   sidebarOpenState,
   viewModeState,
   stickerVisibilityState,
 } from "@store/atoms";
 import { getNextMonth, getPreviousMonth, monthNames } from "@utils/calendar";
+import { addDays, addWeeks, subDays, subWeeks, format } from "date-fns";
+import { ko } from "date-fns/locale";
 import styles from "./Header.module.scss";
 
 const Header: React.FC = () => {
   const [currentMonth, setCurrentMonth] = useRecoilState(currentMonthState);
+  const [selectedDate, setSelectedDate] = useRecoilState(selectedDateState);
   const [sidebarOpen, setSidebarOpen] = useRecoilState(sidebarOpenState);
   const [viewMode, setViewMode] = useRecoilState(viewModeState);
   const [stickerVisibility, setStickerVisibility] = useRecoilState(
     stickerVisibilityState
   );
 
-  const handlePreviousMonth = () => {
-    setCurrentMonth(getPreviousMonth(currentMonth));
+  const handlePrevious = () => {
+    if (viewMode === "day") {
+      const newDate = subDays(selectedDate, 1);
+      setSelectedDate(newDate);
+      setCurrentMonth(newDate);
+    } else if (viewMode === "week") {
+      const newDate = subWeeks(selectedDate, 1);
+      setSelectedDate(newDate);
+      setCurrentMonth(newDate);
+    } else {
+      setCurrentMonth(getPreviousMonth(currentMonth));
+    }
   };
 
-  const handleNextMonth = () => {
-    setCurrentMonth(getNextMonth(currentMonth));
+  const handleNext = () => {
+    if (viewMode === "day") {
+      const newDate = addDays(selectedDate, 1);
+      setSelectedDate(newDate);
+      setCurrentMonth(newDate);
+    } else if (viewMode === "week") {
+      const newDate = addWeeks(selectedDate, 1);
+      setSelectedDate(newDate);
+      setCurrentMonth(newDate);
+    } else {
+      setCurrentMonth(getNextMonth(currentMonth));
+    }
   };
 
   const handleToday = () => {
-    setCurrentMonth(new Date());
+    const today = new Date();
+    setSelectedDate(today);
+    setCurrentMonth(today);
+  };
+
+  const getDateDisplay = () => {
+    if (viewMode === "day") {
+      return format(selectedDate, "yyyy년 M월 d일 EEEE", { locale: ko });
+    } else if (viewMode === "week") {
+      return format(selectedDate, "yyyy년 M월", { locale: ko });
+    } else {
+      return `${currentMonth.getFullYear()}년 ${monthNames[currentMonth.getMonth()]}`;
+    }
   };
 
   return (
@@ -42,15 +78,13 @@ const Header: React.FC = () => {
       </div>
 
       <div className={styles.centerSection}>
-        <button className={styles.navButton} onClick={handlePreviousMonth}>
+        <button className={styles.navButton} onClick={handlePrevious}>
           ←
         </button>
         <div className={styles.currentMonth}>
-          <h2>
-            {currentMonth.getFullYear()}년 {monthNames[currentMonth.getMonth()]}
-          </h2>
+          <h2>{getDateDisplay()}</h2>
         </div>
-        <button className={styles.navButton} onClick={handleNextMonth}>
+        <button className={styles.navButton} onClick={handleNext}>
           →
         </button>
         <button className={styles.todayButton} onClick={handleToday}>

--- a/src/components/Sidebar/EventDetail.module.scss
+++ b/src/components/Sidebar/EventDetail.module.scss
@@ -1,0 +1,153 @@
+@use '@styles/variables' as *;
+@use '@styles/mixins' as *;
+
+.eventDetail {
+  background: var(--color-background);
+  padding: $spacing-md;
+  border-radius: $border-radius;
+  margin-bottom: $spacing-md;
+}
+
+.detailHeader {
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+  margin-bottom: $spacing-lg;
+  padding-bottom: $spacing-sm;
+  border-bottom: 1px solid var(--color-border);
+
+  h3 {
+    flex: 1;
+    font-size: $font-size-large;
+    font-weight: 600;
+    color: var(--color-text);
+    margin: 0;
+  }
+}
+
+.closeButton {
+  width: 32px;
+  height: 32px;
+  border: none;
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+  font-size: $font-size-large;
+  cursor: pointer;
+  border-radius: $border-radius-small;
+  transition: all $transition-fast;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  &:hover {
+    background: var(--color-accent);
+    color: var(--color-text);
+  }
+}
+
+.detailBody {
+  position: relative;
+}
+
+.colorBar {
+  width: 100%;
+  height: 4px;
+  border-radius: $border-radius-small;
+  margin-bottom: $spacing-md;
+}
+
+.detailContent {
+  // No margin needed
+}
+
+.detailGroup {
+  margin-bottom: $spacing-md;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  label {
+    display: block;
+    font-size: $font-size-small;
+    font-weight: 500;
+    color: var(--color-text-secondary);
+    margin-bottom: $spacing-xs;
+  }
+}
+
+.detailValue {
+  padding: $spacing-sm;
+  border: 1px solid var(--color-border);
+  border-radius: $border-radius-small;
+  background: var(--color-surface);
+  font-size: $font-size-base;
+  color: var(--color-text);
+  line-height: 1.5;
+  min-height: 38px;
+  display: flex;
+  align-items: center;
+  gap: $spacing-sm;
+}
+
+.recurringBadge {
+  display: inline-block;
+  margin-left: $spacing-sm;
+  padding: 2px $spacing-sm;
+  background: var(--color-primary);
+  color: white;
+  font-size: $font-size-small;
+  font-weight: 500;
+  border-radius: $border-radius-small;
+}
+
+.recurrenceEnd {
+  margin-top: $spacing-xs;
+  font-size: $font-size-small;
+  color: var(--color-text-secondary);
+}
+
+.detailActions {
+  display: flex;
+  gap: $spacing-sm;
+  margin-top: $spacing-lg;
+}
+
+.editButton,
+.deleteButton {
+  flex: 1;
+  padding: $spacing-sm $spacing-md;
+  border: none;
+  border-radius: $border-radius-small;
+  cursor: pointer;
+  font-size: $font-size-base;
+  font-weight: 500;
+  transition: all $transition-fast;
+}
+
+.editButton {
+  background: var(--color-primary);
+  color: white;
+
+  &:hover {
+    background: var(--color-secondary);
+    transform: translateY(-2px);
+    box-shadow: $shadow-small;
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+}
+
+.deleteButton {
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+
+  &:hover {
+    background: var(--color-danger-light);
+    color: var(--color-danger);
+    border-color: var(--color-danger);
+  }
+}

--- a/src/components/Sidebar/EventDetail.tsx
+++ b/src/components/Sidebar/EventDetail.tsx
@@ -1,0 +1,149 @@
+import React from "react";
+import { useRecoilState, useSetRecoilState } from "recoil";
+import { selectedEventState, eventsState } from "@store/atoms";
+import { Event } from "@types";
+import { format } from "date-fns";
+import { ko } from "date-fns/locale";
+import toast from "react-hot-toast";
+import styles from "./EventDetail.module.scss";
+
+interface EventDetailProps {
+  event: Event;
+  onEdit: () => void;
+}
+
+const EventDetail: React.FC<EventDetailProps> = ({ event, onEdit }) => {
+  const [selectedEvent, setSelectedEvent] = useRecoilState(selectedEventState);
+  const setEvents = useSetRecoilState(eventsState);
+
+  const handleClose = () => {
+    setSelectedEvent(null);
+  };
+
+  const handleDelete = () => {
+    if (confirm("이 이벤트를 삭제하시겠습니까?")) {
+      setEvents((prev) => prev.filter((e) => e.id !== event.id));
+      setSelectedEvent(null);
+      toast.success("이벤트가 삭제되었습니다");
+    }
+  };
+
+  const formatTime = (time?: string) => {
+    if (!time) return "";
+    const [hours, minutes] = time.split(":");
+    const hour = parseInt(hours);
+    const ampm = hour >= 12 ? "오후" : "오전";
+    const displayHour = hour % 12 || 12;
+    return `${ampm} ${displayHour}:${minutes}`;
+  };
+
+  return (
+    <div className={styles.eventDetail}>
+      <div className={styles.detailHeader}>
+        <button className={styles.closeButton} onClick={handleClose}>
+          ←
+        </button>
+        <h3>이벤트 상세</h3>
+      </div>
+
+      <div className={styles.detailBody}>
+        <div className={styles.detailContent}>
+          <div className={styles.detailGroup}>
+            <label>제목</label>
+            <div className={styles.detailValue}>
+              {event.title}
+              {event.recurrence && (
+                <span className={styles.recurringBadge}>반복</span>
+              )}
+            </div>
+          </div>
+
+          <div className={styles.detailGroup}>
+            <label>날짜</label>
+            <div className={styles.detailValue}>
+              {event.endDate && event.date !== event.endDate ? (
+                <>
+                  {format(event.date, "yyyy년 MM월 dd일", { locale: ko })} ~{" "}
+                  {format(event.endDate, "yyyy년 MM월 dd일", { locale: ko })}
+                </>
+              ) : (
+                format(event.date, "yyyy년 MM월 dd일 EEEE", { locale: ko })
+              )}
+            </div>
+          </div>
+
+          {(event.startTime || event.endTime || event.isAllDay) && (
+            <div className={styles.detailGroup}>
+              <label>시간</label>
+              <div className={styles.detailValue}>
+                {event.isAllDay ? (
+                  "하루 종일"
+                ) : (
+                  <>
+                    {formatTime(event.startTime)}
+                    {event.endTime && ` - ${formatTime(event.endTime)}`}
+                  </>
+                )}
+              </div>
+            </div>
+          )}
+
+          {event.recurrence && (
+            <div className={styles.detailGroup}>
+              <label>반복</label>
+              <div className={styles.detailValue}>
+                {event.recurrence.frequency === "daily" && "매일"}
+                {event.recurrence.frequency === "weekly" && "매주"}
+                {event.recurrence.frequency === "monthly" && "매월"}
+                {event.recurrence.frequency === "yearly" && "매년"}
+                {event.recurrence.interval && event.recurrence.interval > 1 && (
+                  <> {event.recurrence.interval}번마다</>
+                )}
+                {event.recurrence.endDate && (
+                  <div className={styles.recurrenceEnd}>
+                    종료:{" "}
+                    {format(event.recurrence.endDate, "yyyy년 MM월 dd일", {
+                      locale: ko,
+                    })}
+                  </div>
+                )}
+              </div>
+            </div>
+          )}
+
+          {event.reminder && event.reminderTime && (
+            <div className={styles.detailGroup}>
+              <label>알림</label>
+              <div className={styles.detailValue}>
+                {event.reminderTime === "now" &&
+                  (event.isAllDay ? "자정 (00:00)" : "이벤트 시작 시")}
+                {event.reminderTime === "5min" && "5분 전"}
+                {event.reminderTime === "10min" && "10분 전"}
+                {event.reminderTime === "30min" && "30분 전"}
+                {event.reminderTime === "1hour" && "1시간 전"}
+              </div>
+            </div>
+          )}
+
+          {event.description && (
+            <div className={styles.detailGroup}>
+              <label>설명</label>
+              <div className={styles.detailValue}>{event.description}</div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className={styles.detailActions}>
+        <button className={styles.editButton} onClick={onEdit}>
+          수정
+        </button>
+        <button className={styles.deleteButton} onClick={handleDelete}>
+          삭제
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default EventDetail;

--- a/src/components/Sidebar/EventDetail.tsx
+++ b/src/components/Sidebar/EventDetail.tsx
@@ -50,12 +50,7 @@ const EventDetail: React.FC<EventDetailProps> = ({ event, onEdit }) => {
         <div className={styles.detailContent}>
           <div className={styles.detailGroup}>
             <label>제목</label>
-            <div className={styles.detailValue}>
-              {event.title}
-              {event.recurrence && (
-                <span className={styles.recurringBadge}>반복</span>
-              )}
-            </div>
+            <div className={styles.detailValue}>{event.title}</div>
           </div>
 
           <div className={styles.detailGroup}>
@@ -98,14 +93,6 @@ const EventDetail: React.FC<EventDetailProps> = ({ event, onEdit }) => {
                 {event.recurrence.frequency === "yearly" && "매년"}
                 {event.recurrence.interval && event.recurrence.interval > 1 && (
                   <> {event.recurrence.interval}번마다</>
-                )}
-                {event.recurrence.endDate && (
-                  <div className={styles.recurrenceEnd}>
-                    종료:{" "}
-                    {format(event.recurrence.endDate, "yyyy년 MM월 dd일", {
-                      locale: ko,
-                    })}
-                  </div>
                 )}
               </div>
             </div>

--- a/src/components/Sidebar/EventForm.tsx
+++ b/src/components/Sidebar/EventForm.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from "react";
 import { useSetRecoilState } from "recoil";
-import { eventsState } from "@store/atoms";
+import { eventsState, selectedEventState } from "@store/atoms";
 import { Event, RecurrenceRule, ReminderTime } from "@types";
 import { v4 as uuidv4 } from "uuid";
 import { format, isAfter } from "date-fns";
@@ -16,6 +16,7 @@ interface EventFormProps {
 
 const EventForm: React.FC<EventFormProps> = ({ date, onClose, event }) => {
   const setEvents = useSetRecoilState(eventsState);
+  const setSelectedEvent = useSetRecoilState(selectedEventState);
   const [title, setTitle] = useState(event?.title || "");
   const [startDate, setStartDate] = useState(
     format(event?.date || date, "yyyy-MM-dd")
@@ -115,6 +116,8 @@ const EventForm: React.FC<EventFormProps> = ({ date, onClose, event }) => {
     // 성공 메시지 표시
     toast.success(event ? '이벤트가 수정되었습니다' : '이벤트가 추가되었습니다');
 
+    // 선택된 이벤트 초기화
+    setSelectedEvent(null);
     onClose();
   };
 

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,7 +1,8 @@
-import React, { useState } from 'react';
-import { useRecoilState, useRecoilValue } from 'recoil';
+import React, { useState, useEffect } from 'react';
+import { useRecoilState, useRecoilValue, useSetRecoilState } from 'recoil';
 import {
   selectedDateState,
+  selectedEventState,
   eventsState,
   diaryEntriesState,
   sidebarOpenState
@@ -18,10 +19,30 @@ import styles from './Sidebar.module.scss';
 const Sidebar: React.FC = () => {
   const [sidebarOpen] = useRecoilState(sidebarOpenState);
   const selectedDate = useRecoilValue(selectedDateState);
+  const setSelectedEvent = useSetRecoilState(selectedEventState);
   const events = useRecoilValue(eventsState);
   const diaryEntries = useRecoilValue(diaryEntriesState);
   const [activeTab, setActiveTab] = useState<'events' | 'diary'>('events');
   const [showEventForm, setShowEventForm] = useState(false);
+
+  // 날짜가 변경되면 선택된 이벤트 초기화
+  useEffect(() => {
+    setSelectedEvent(null);
+  }, [selectedDate, setSelectedEvent]);
+
+  // 탭이 변경되면 선택된 이벤트 초기화
+  const handleTabChange = (tab: 'events' | 'diary') => {
+    setActiveTab(tab);
+    setSelectedEvent(null);
+  };
+
+  // 이벤트 추가 폼을 열 때 선택된 이벤트 초기화
+  const handleToggleEventForm = () => {
+    setShowEventForm(!showEventForm);
+    if (!showEventForm) {
+      setSelectedEvent(null);
+    }
+  };
 
   // 반복 이벤트를 포함하여 선택된 날짜의 이벤트 가져오기
   // 선택된 날짜 기준 3개월 범위로 반복 이벤트 계산
@@ -48,13 +69,13 @@ const Sidebar: React.FC = () => {
         <div className={styles.tabs}>
           <button
             className={`${styles.tab} ${activeTab === 'events' ? styles.active : ''}`}
-            onClick={() => setActiveTab('events')}
+            onClick={() => handleTabChange('events')}
           >
             이벤트
           </button>
           <button
             className={`${styles.tab} ${activeTab === 'diary' ? styles.active : ''}`}
-            onClick={() => setActiveTab('diary')}
+            onClick={() => handleTabChange('diary')}
           >
             일기
           </button>
@@ -67,7 +88,7 @@ const Sidebar: React.FC = () => {
             <div className={styles.actionBar}>
               <button
                 className={styles.addButton}
-                onClick={() => setShowEventForm(!showEventForm)}
+                onClick={handleToggleEventForm}
               >
                 {showEventForm ? '취소' : '+ 이벤트 추가'}
               </button>

--- a/src/store/atoms.ts
+++ b/src/store/atoms.ts
@@ -174,6 +174,11 @@ export const selectedDateState = atom<Date>({
   default: new Date()
 });
 
+export const selectedEventState = atom<Event | null>({
+  key: 'selectedEvent',
+  default: null
+});
+
 export const currentMonthState = atom<Date>({
   key: 'currentMonth',
   default: startOfMonth(new Date())


### PR DESCRIPTION
- 일간 뷰: 어제/내일로 이동
- 주간 뷰: 이전 주/다음 주로 이동
- 월간 뷰: 이전 달/다음 달로 이동 (기존 동작 유지)

헤더 날짜 표시 형식 변경:
- 일간 뷰: yyyy년 M월 d일 요일 표시
- 주간 뷰: yyyy년 M월 표시
- 월간 뷰: yyyy년 M월 표시 (기존 동작 유지)

오늘 버튼 클릭 시 selectedDate도 함께 업데이트

🤖 Generated with [Claude Code](https://claude.ai/code)