### PR TITLE
fix: Window환경에서 커스텀 타이틀바 제외

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -43,8 +43,8 @@ function createWindow() {
       webgl: true,
       experimentalFeatures: true,
     },
-    // Windows에서는 frameless, macOS에서는 hidden 사용
-    ...(isWindows ? { frame: false } : { titleBarStyle: "hidden" }),
+    // Windows에서는 menu hide, macOS에서는 hidden 사용
+    ...(isWindows ? { frame:true, autoHideMenuBar: true  } : { titleBarStyle: "hidden" }),
     // macOS에서 트래픽 라이트 버튼 위치 조정
     ...(isMac ? { trafficLightPosition: { x: 15, y: 13 } } : {}),
     backgroundColor: "#faf8f5",

--- a/src/App.module.scss
+++ b/src/App.module.scss
@@ -10,6 +10,11 @@
   box-sizing: border-box;
 }
 
+.winSystemTitleBar {
+  padding-top: 0px;
+  border-top: 1px solid var(--color-border);
+}
+
 .mainContent {
   flex: 1;
   display: flex;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,7 @@ function App() {
   useTheme(); // Apply theme automatically
   const previousStickersRef = useRef(stickers);
   const isEditModeStartingRef = useRef(false);
-
+  const isWindows = useRef(false);
   // 앱 시작 시 이전 상태 복원
   useEffect(() => {
     document.title = "";
@@ -54,6 +54,11 @@ function App() {
 
     restoreAppState();
 
+    if (window.electronAPI?.getPlatform) {
+      window.electronAPI.getPlatform()
+        .then(platform => { isWindows.current = platform === 'win32';})
+        .catch(() => {isWindows.current = false});
+    }
     // Start notification service
     notificationService.start();
 
@@ -132,7 +137,7 @@ function App() {
   };
 
   return (
-    <div className={styles.app}>
+    <div className={`${styles.app} ${isWindows.current ?  styles.winSystemTitleBar : '' }`}>
       <Toaster
         position="top-right"
         toastOptions={{
@@ -153,7 +158,7 @@ function App() {
           },
         }}
       />
-      <WindowTitleBar />
+
       <TitleBar />
       <Header />
       <div className={styles.mainContent}>

--- a/src/components/Layout/TitleBar.tsx
+++ b/src/components/Layout/TitleBar.tsx
@@ -3,8 +3,13 @@ import styles from "./TitleBar.module.scss";
 
 const TitleBar: React.FC = () => {
   const [currentTime, setCurrentTime] = useState(new Date());
+  const [platform, setPlatform] = useState<string>('');
 
   useEffect(() => {
+    // 플랫폼 체크
+    if (window.electronAPI?.getPlatform) {
+      window.electronAPI.getPlatform().then(setPlatform);
+    }
     const timer = setInterval(() => {
       setCurrentTime(new Date());
     }, 1000);
@@ -12,6 +17,11 @@ const TitleBar: React.FC = () => {
     return () => clearInterval(timer);
   }, []);
 
+  // Windows 플랫폼인 경우 타이틀바를 표시하지 않음
+  if (platform === 'win32') {
+    return null;
+  }
+  
   return (
     <div className={styles.titleBar}>
       <div className={styles.dragRegion}>


### PR DESCRIPTION
- 커스텀 타이틀 삭제 후 여유공간 제거를 위한 CSS 추가
- 시스템 타이틀의 메뉴바 hide